### PR TITLE
Add season 17 and Havana

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ import './primer.css'
 import './ionicons.min.css'
 import './App.css'
 
-const latestKnownSeason = 16
+const latestKnownSeason = 17
 const { ipcRenderer, remote } = ElectronUtils
 const { dialog } = remote
 

--- a/src/components/MatchTableRow.css
+++ b/src/components/MatchTableRow.css
@@ -197,7 +197,7 @@
 }
 
 .theme-dark .background-havana {
-  background-color: #61beae;
+  background-color: #44867b;
 }
 
 .theme-dark .background-hollywood {

--- a/src/components/MatchTableRow.css
+++ b/src/components/MatchTableRow.css
@@ -112,6 +112,10 @@
   background-color: #2aa6fb;
 }
 
+.background-havana {
+  background-color: #77e3d1;
+}
+
 .background-hollywood {
   background-color: #92d8fd;
 }
@@ -190,6 +194,10 @@
 
 .theme-dark .background-blizzard-world {
   background-color: #0471bb;
+}
+
+.theme-dark .background-havana {
+  background-color: #61beae;
 }
 
 .theme-dark .background-hollywood {

--- a/src/models/Map.js
+++ b/src/models/Map.js
@@ -5,6 +5,7 @@ export default {
     'Dorado',
     'Eichenwalde',
     'Hanamura',
+    'Havana',
     'Hollywood',
     'Horizon Lunar Colony',
     'Ilios',
@@ -45,6 +46,7 @@ export default {
     ],
     Escort: [
       'Dorado',
+      'Havana',
       'Junkertown',
       'Rialto',
       'Route 66',
@@ -64,4 +66,3 @@ export default {
     Escort: 'Payload'
   }
 }
-


### PR DESCRIPTION
Hi there! 👋 

Thanks so much again for making this app, I use it to track my competitive games across my different accounts ✨ 😄.

I noticed that season 17 and Havana hadn't been added yet, so I figured I'd open a PR to add them!

I wasn't sure how you decided what colors to use for each row... I added a turquoise color that is similar to what is used on the map, but open to whatever colors you think would be best!


Light mode:
![Screen Shot 2019-07-02 at 9 29 06 PM](https://user-images.githubusercontent.com/858504/60564441-805d0f80-9d14-11e9-8120-971d39cfc7ad.png)

Dark mode:
![Screen Shot 2019-07-02 at 9 36 00 PM](https://user-images.githubusercontent.com/858504/60564443-82bf6980-9d14-11e9-9a0e-3f83d3969366.png)

/cc @cheshire137